### PR TITLE
Fix generating site link in getting started

### DIFF
--- a/gettingstarted.md
+++ b/gettingstarted.md
@@ -63,4 +63,4 @@ your `$PATH`.
 # Installation completed
 After following these steps you should have successfully installed cldoc!
 Continue to [Documenting code](documenting.html) or directly to
-[Generating site](generatingsite.html).
+[Generating site](generating.html).


### PR DESCRIPTION
On http://jessevdk.github.com/cldoc/gettingstarted.html, the link Generating site is pointing to http://jessevdk.github.com/cldoc/generatingsite.html - which is bad, as the page is named generating.html.
