### PR TITLE
[cldoc][node] Removing import from nonexistent module

### DIFF
--- a/cldoc/nodes/__init__.py
+++ b/cldoc/nodes/__init__.py
@@ -27,7 +27,6 @@ from .method import *
 from .namespace import *
 from .node import *
 from .root import *
-from .templatetype import *
 from .typedef import *
 from .union import *
 from .variable import *


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/jessevdk/cldoc/issues/18), installing and running the master image currently results in error when attempting to issue various commands.  This is because `clang/nodes/__init__.py` is importing from a module that isn't defined in the project.

This pull request is a single line change that removes this import statement.

I have tested this on my local development machine (64-bit ArchLinux), and after building a new `cldoc` with this changset applied, I now am able to generate documentation.
