### PR TITLE
cldoc:<instruction>() handling

### DIFF
--- a/cldoc/comment.py
+++ b/cldoc/comment.py
@@ -378,8 +378,15 @@ class CommentsDatabase(object):
 
             cleaned = self.clean(token)
 
-            if not cleaned is None:
+            if not cleaned is None and "cldoc:" not in cleaned:
                 comments.append(cleaned)
+            # Before concat execute cldoc:<instruction>() comments
+            # This stops documentation comments getting eaten by instruction
+            # comments.
+            elif "cldoc:" in cleaned:
+                self.extract_one(token, cleaned)
+                token = iter.next()
+                continue
 
             prev = token
             token = iter.next()


### PR DESCRIPTION
Fixed problem with early comment concatination which made
cldoc:<instruciton>() comments eat the comments around it.

For example:

```
/* cldoc:begin-category(Something) */

/* this is documentation about something below (this got eaten) */
extern int something;
```
