### PR TITLE
[example] fixed breaking example

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -15,11 +15,11 @@ clean:
 
 doc:
 	@echo "Generating documentation..."; \
-	cldoc $(CXXFLAGS) -- 		\
+	cldoc generate $(CXXFLAGS) --	\
 		--report 		\
 		--merge docs 		\
 		--output html 		\
 		$(SOURCES) $(HEADERS)
 
 serve:
-	cldoc -- --output html --serve
+	cldoc serve html


### PR DESCRIPTION
The example is broken because cldoc command has changed since 1.4.

This patch make example works again by using new cldoc command.

Signed-off-by: Kai Zhang kyle@zelin.io
