### PR TITLE
Fix exceptions raised when parsing my codebase.

### DIFF
--- a/cldoc/comment.py
+++ b/cldoc/comment.py
@@ -373,17 +373,17 @@ class CommentsDatabase(object):
         while token.kind == cindex.TokenKind.COMMENT:
             cleaned = self.clean(token)
 
-            # Process instructions directly, now
-            if not CommentsDatabase.cldoc_instrre.match(cleaned) is None:
-                comments = [cleaned]
-                break
+            if cleaned is not None:
+                # Process instructions directly, now
+                if not CommentsDatabase.cldoc_instrre.match(cleaned) is None:
+                    comments = [cleaned]
+                    break
 
-            # Check adjacency
-            if not prev is None and prev.extent.end.line + 1 < token.extent.start.line:
-                # Empty previous comment
-                comments = []
+                # Check adjacency
+                if not prev is None and prev.extent.end.line + 1 < token.extent.start.line:
+                    # Empty previous comment
+                    comments = []
 
-            if not cleaned is None:
                 comments.append(cleaned)
 
             prev = token

--- a/cldoc/nodes/method.py
+++ b/cldoc/nodes/method.py
@@ -36,29 +36,28 @@ class Method(Function):
 
     @property
     def override(self):
-        if not self._override is None:
-            return self._override
+        if self._override is None:
+            self._override = []
 
-        # Lookup in bases, recursively
-        bases = list(self.parent.bases)
-        mname = self.name
+            if hasattr(self.parent, 'bases'):
+                # Lookup in bases, recursively
+                bases = list(self.parent.bases)
+                mname = self.name
 
-        self._override = []
+                while len(bases) > 0:
+                    b = bases[0]
+                    bases = bases[1:]
 
-        while len(bases) > 0:
-            b = bases[0]
-            bases = bases[1:]
+                    if not b.node:
+                        continue
 
-            if not b.node:
-                continue
+                    b = b.node
 
-            b = b.node
-
-            if mname in b.name_to_method:
-                self._override.append(b.name_to_method[mname])
-            else:
-                # Look in the bases of bases also
-                bases = bases + b.bases
+                    if mname in b.name_to_method:
+                        self._override.append(b.name_to_method[mname])
+                    else:
+                        # Look in the bases of bases also
+                        bases = bases + b.bases
 
         return self._override
 


### PR DESCRIPTION
These were the two errors:

```
...
File "cldoc/cldoc/comment.py", line 377, in extract_loop
    if not CommentsDatabase.cldoc_instrre.match(cleaned) is None:
TypeError: expected string or buffer
```

and

```
File "cldoc/cldoc/nodes/method.py", line 43, in override
    bases = list(self.parent.bases)
AttributeError: 'Union' object has no attribute 'bases'
```
