### PR TITLE
updated cindex.py to work with clang 3.4

### DIFF
--- a/cldoc/clang/cindex.py
+++ b/cldoc/clang/cindex.py
@@ -1456,6 +1456,10 @@ TypeKind.FUNCTIONNOPROTO = TypeKind(110)
 TypeKind.FUNCTIONPROTO = TypeKind(111)
 TypeKind.CONSTANTARRAY = TypeKind(112)
 TypeKind.VECTOR = TypeKind(113)
+TypeKind.INCOMPLETEARRAY = TypeKind(114)
+TypeKind.VARIABLEARRAY = TypeKind(115)
+TypeKind.DEPENDENTSIZEDARRAY = TypeKind(116)
+TypeKind.MEMBERPOINTER = TypeKind(117)
 
 class Type(Structure):
     """
@@ -2020,7 +2024,7 @@ class TranslationUnit(ClangObject):
                                     len(args), unsaved_array,
                                     len(unsaved_files), options)
 
-        if ptr is None or not bool(ptr):
+        if ptr is None:
             raise TranslationUnitLoadError("Error parsing translation unit.")
 
         return cls(ptr, index=index)


### PR DESCRIPTION
This solves the clang 3.4 issue, but haven't extensively tested on clang < 3.4
