### PR TITLE
Check C constructor hints as prefix and suffix

### DIFF
--- a/cldoc/tree.py
+++ b/cldoc/tree.py
@@ -301,8 +301,8 @@ class Tree(documentmerger.DocumentMerger):
         hints = ['new', 'init', 'alloc', 'create']
 
         for hint in hints:
-            if node.name.startswith(hint+"_") or \
-               node.name.endswith("_"+hint):
+            if node.name.startswith(hint + "_") or \
+               node.name.endswith("_" + hint):
                 return True
 
         return False


### PR DESCRIPTION
struct foo\* create_foo() is another way of constructing foo. Some would argue it is even more readable than struct foo\* foo_create() ;)
