### PR TITLE
CMake: Manually specify the path to cldoc

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,7 +7,12 @@ set(HEADERS transport/bicycle.hh transport/mountainbike.hh transport/racingbike.
 include_directories("${PROJECT_SOURCE_DIR}")
 add_library(transport ${SOURCES})
 
-find_program(CLDOC cldoc)
+set(CLDOC "" CACHE STRING "User specified '/path/to/cldoc'")
+if(CLDOC STREQUAL "")
+	find_program(CLDOC cldoc)
+elseif(NOT EXISTS ${CLDOC})
+	message(FATAL_ERROR "CLDOC was set to '${CLDOC}' but does not exist")
+endif()
 
 if(NOT DOCS_OUTPUT_DIR)
 	set(DOCS_OUTPUT_DIR "gendocs" CACHE STRING "Generated documentation output directory" FORCE)


### PR DESCRIPTION
In the event the user invoking CMake does not have cldoc installed
on the system path, the CLDOC variable can be set manually using
cmake -DCLDOC:STRING=/path/to/cldoc /path/to/CMakeLists.txt
