### PR TITLE
Fix issue #43 and update cindex.py

### DIFF
--- a/cldoc/clang/README.md
+++ b/cldoc/clang/README.md
@@ -4,8 +4,8 @@ This is an import of the python bindings for libclang taken from the
 `bindings/python/clang` directory of the
 [clang](https://github.com/llvm-mirror/clang) repository.
 
-The files are taken from commit 52bb2a06361d1d0d51809a2ac06e270e8cf05a9e
-(SVN commit 179984), with the modifications listed in
+The files are taken from commit 8c099d9b04f0b3025e713f76b42a50f3a67d404f
+(SVN commit 193725), with the modifications listed in
 `cldoc/clang/cindex-updates.patch`.
 
 To apply the cldoc changes, run:

--- a/cldoc/clang/cindex-updates.patch
+++ b/cldoc/clang/cindex-updates.patch
@@ -1,5 +1,5 @@
 diff --git b/cldoc/clang/cindex.py a/cldoc/clang/cindex.py
-index 880a150..a4ec931 100644
+index c103c70..6098c34 100644
 --- b/cldoc/clang/cindex.py
 +++ a/cldoc/clang/cindex.py
 @@ -1,3 +1,15 @@
@@ -27,7 +27,7 @@ index 880a150..a4ec931 100644
  
  # ctypes doesn't implicitly convert c_void_p to the appropriate wrapper
  # object. This is a problem, because it means that from_parameter will see an
-@@ -352,6 +364,13 @@ class Diagnostic(object):
+@@ -375,6 +387,13 @@ class Diagnostic(object):
          return conf.lib.clang_getDiagnosticOption(self, None)
  
      @property
@@ -41,7 +41,7 @@ index 880a150..a4ec931 100644
      def disable_option(self):
          """The command-line option that disables this diagnostic."""
          disable = _CXString()
-@@ -1073,6 +1092,12 @@ class Cursor(Structure):
+@@ -1130,6 +1149,12 @@ class Cursor(Structure):
          """
          return conf.lib.clang_CXXMethod_isStatic(self)
  
@@ -54,7 +54,7 @@ index 880a150..a4ec931 100644
      def get_definition(self):
          """
          If the cursor is a reference to a declaration or a declaration of
-@@ -1083,6 +1108,13 @@ class Cursor(Structure):
+@@ -1140,6 +1165,13 @@ class Cursor(Structure):
          # declaration prior to issuing the lookup.
          return conf.lib.clang_getCursorDefinition(self)
  
@@ -68,7 +68,7 @@ index 880a150..a4ec931 100644
      def get_usr(self):
          """Return the Unified Symbol Resultion (USR) for the entity referenced
          by the given cursor (or None).
-@@ -1248,6 +1280,9 @@ class Cursor(Structure):
+@@ -1305,6 +1337,9 @@ class Cursor(Structure):
  
          return self._hash
  
@@ -78,18 +78,7 @@ index 880a150..a4ec931 100644
      @property
      def semantic_parent(self):
          """Return the semantic parent for this cursor."""
-@@ -1450,6 +1485,10 @@ TypeKind.FUNCTIONNOPROTO = TypeKind(110)
- TypeKind.FUNCTIONPROTO = TypeKind(111)
- TypeKind.CONSTANTARRAY = TypeKind(112)
- TypeKind.VECTOR = TypeKind(113)
-+TypeKind.INCOMPLETEARRAY = TypeKind(114)
-+TypeKind.VARIABLEARRAY = TypeKind(115)
-+TypeKind.DEPENDENTSIZEDARRAY = TypeKind(116)
-+TypeKind.MEMBERPOINTER = TypeKind(117)
- 
- class Type(Structure):
-     """
-@@ -1936,6 +1975,33 @@ class Index(ClangObject):
+@@ -2069,6 +2104,33 @@ class Index(ClangObject):
          return TranslationUnit.from_source(path, args, unsaved_files, options,
                                             self)
  
@@ -123,7 +112,7 @@ index 880a150..a4ec931 100644
  class TranslationUnit(ClangObject):
      """Represents a source code translation unit.
  
-@@ -2611,6 +2677,15 @@ functionList = [
+@@ -2748,6 +2810,15 @@ functionList = [
    ("clang_disposeDiagnostic",
     [Diagnostic]),
  
@@ -139,7 +128,7 @@ index 880a150..a4ec931 100644
    ("clang_disposeIndex",
     [Index]),
  
-@@ -3224,7 +3299,7 @@ class Config:
+@@ -3385,7 +3456,7 @@ class Config:
          return True
  
  def register_enumerations():

--- a/cldoc/clang/cindex.py
+++ b/cldoc/clang/cindex.py
@@ -278,6 +278,29 @@ class SourceRange(Structure):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __contains__(self, other):
+        """Useful to detect the Token/Lexer bug"""
+        if not isinstance(other, SourceLocation):
+            return False
+        if other.file is None and self.start.file is None:
+            pass
+        elif ( self.start.file.name != other.file.name or 
+               other.file.name != self.end.file.name):
+            # same file name
+            return False
+        # same file, in between lines
+        if self.start.line < other.line < self.end.line:
+            return True
+        elif self.start.line == other.line:
+            # same file first line
+            if self.start.column <= other.column:
+                return True
+        elif other.line == self.end.line:
+            # same file last line
+            if other.column <= self.end.column:
+                return True
+        return False
+
     def __repr__(self):
         return "<SourceRange start %r, end %r>" % (self.start, self.end)
 
@@ -527,7 +550,7 @@ class CursorKind(object):
     @staticmethod
     def from_id(id):
         if id >= len(CursorKind._kinds) or CursorKind._kinds[id] is None:
-            raise ValueError,'Unknown cursor kind'
+            raise ValueError,'Unknown cursor kind %d' % id
         return CursorKind._kinds[id]
 
     @staticmethod
@@ -740,9 +763,13 @@ CursorKind.MEMBER_REF = CursorKind(47)
 # A reference to a labeled statement.
 CursorKind.LABEL_REF = CursorKind(48)
 
-# A reference toa a set of overloaded functions or function templates
+# A reference to a set of overloaded functions or function templates
 # that has not yet been resolved to a specific function or function template.
 CursorKind.OVERLOADED_DECL_REF = CursorKind(49)
+
+# A reference to a variable that occurs in some non-expression 
+# context, e.g., a C++ lambda capture list.
+CursorKind.VARIABLE_REF = CursorKind(50)
 
 ###
 # Invalid/Error Kinds
@@ -927,6 +954,26 @@ CursorKind.PACK_EXPANSION_EXPR = CursorKind(142)
 # pack.
 CursorKind.SIZE_OF_PACK_EXPR = CursorKind(143)
 
+# Represents a C++ lambda expression that produces a local function
+# object.
+# 
+#  \code
+#  void abssort(float *x, unsigned N) {
+#    std::sort(x, x + N,
+#              [](float a, float b) {
+#                return std::abs(a) < std::abs(b);
+#              });
+#  }
+#  \endcode
+CursorKind.LAMBDA_EXPR = CursorKind(144)
+  
+# Objective-c Boolean Literal.
+CursorKind.OBJ_BOOL_LITERAL_EXPR = CursorKind(145)
+
+# Represents the "self" expression in a ObjC method.
+CursorKind.OBJ_SELF_EXPR = CursorKind(146)
+
+
 # A statement whose specific kind is not exposed via this interface.
 #
 # Unexposed statements have the same operations as any other kind of statement;
@@ -1018,6 +1065,9 @@ CursorKind.SEH_EXCEPT_STMT = CursorKind(227)
 # Windows Structured Exception Handling's finally statement.
 CursorKind.SEH_FINALLY_STMT = CursorKind(228)
 
+# A MS inline assembly statement extension.
+CursorKind.MS_ASM_STMT = CursorKind(229)
+
 # The null statement.
 CursorKind.NULL_STMT = CursorKind(230)
 
@@ -1047,6 +1097,7 @@ CursorKind.CXX_FINAL_ATTR = CursorKind(404)
 CursorKind.CXX_OVERRIDE_ATTR = CursorKind(405)
 CursorKind.ANNOTATE_ATTR = CursorKind(406)
 CursorKind.ASM_LABEL_ATTR = CursorKind(407)
+CursorKind.PACKED_ATTR = CursorKind(408)
 
 ###
 # Preprocessing
@@ -1054,6 +1105,12 @@ CursorKind.PREPROCESSING_DIRECTIVE = CursorKind(500)
 CursorKind.MACRO_DEFINITION = CursorKind(501)
 CursorKind.MACRO_INSTANTIATION = CursorKind(502)
 CursorKind.INCLUSION_DIRECTIVE = CursorKind(503)
+
+###
+# Extra declaration
+
+# A module import declaration.
+CursorKind.MODULE_IMPORT_DECL = CursorKind(600)
 
 ### Cursors ###
 
@@ -1317,6 +1374,16 @@ class Cursor(Structure):
 
         return self._referenced
 
+    @property
+    def brief_comment(self):
+        """Returns the brief comment text associated with that Cursor"""
+        return conf.lib.clang_Cursor_getBriefCommentText(self)
+    
+    @property
+    def raw_comment(self):
+        """Returns the raw comment text associated with that Cursor"""
+        return conf.lib.clang_Cursor_getRawCommentText(self)
+
     def get_arguments(self):
         """Return an iterator for accessing the arguments of this cursor."""
         num_args = conf.lib.clang_Cursor_getNumArguments(self)
@@ -1489,6 +1556,50 @@ TypeKind.INCOMPLETEARRAY = TypeKind(114)
 TypeKind.VARIABLEARRAY = TypeKind(115)
 TypeKind.DEPENDENTSIZEDARRAY = TypeKind(116)
 TypeKind.MEMBERPOINTER = TypeKind(117)
+
+class RefQualifierKind(object):
+    """Describes a specific ref-qualifier of a type."""
+
+    # The unique kind objects, indexed by id.
+    _kinds = []
+    _name_map = None
+
+    def __init__(self, value):
+        if value >= len(RefQualifierKind._kinds):
+            num_kinds = value - len(RefQualifierKind._kinds) + 1
+            RefQualifierKind._kinds += [None] * num_kinds
+        if RefQualifierKind._kinds[value] is not None:
+            raise ValueError, 'RefQualifierKind already loaded'
+        self.value = value
+        RefQualifierKind._kinds[value] = self
+        RefQualifierKind._name_map = None
+
+    def from_param(self):
+        return self.value
+
+    @property
+    def name(self):
+        """Get the enumeration name of this kind."""
+        if self._name_map is None:
+            self._name_map = {}
+            for key, value in RefQualifierKind.__dict__.items():
+                if isinstance(value, RefQualifierKind):
+                    self._name_map[value] = key
+        return self._name_map[self]
+
+    @staticmethod
+    def from_id(id):
+        if (id >= len(RefQualifierKind._kinds) or
+                RefQualifierKind._kinds[id] is None):
+            raise ValueError, 'Unknown type kind %d' % id
+        return RefQualifierKind._kinds[id]
+
+    def __repr__(self):
+        return 'RefQualifierKind.%s' % (self.name,)
+
+RefQualifierKind.NONE = RefQualifierKind(0)
+RefQualifierKind.LVALUE = RefQualifierKind(1)
+RefQualifierKind.RVALUE = RefQualifierKind(2)
 
 class Type(Structure):
     """
@@ -1664,6 +1775,12 @@ class Type(Structure):
         """
         return conf.lib.clang_getArraySize(self)
 
+    def get_class_type(self):
+        """
+        Retrieve the class type of the member pointer type.
+        """
+        return conf.lib.clang_Type_getClassType(self)
+
     def get_align(self):
         """
         Retrieve the alignment of the record.
@@ -1681,6 +1798,18 @@ class Type(Structure):
         Retrieve the offset of a field in the record.
         """
         return conf.lib.clang_Type_getOffsetOf(self, c_char_p(fieldname))
+
+    def get_ref_qualifier(self):
+        """
+        Retrieve the ref-qualifier of the type.
+        """
+        return RefQualifierKind.from_id(
+                conf.lib.clang_Type_getCXXRefQualifier(self))
+
+    @property
+    def spelling(self):
+        """Retrieve the spelling of this Type."""
+        return conf.lib.clang_getTypeSpelling(self)
 
     def __eq__(self, other):
         if type(other) != type(self):
@@ -1957,7 +2086,7 @@ class Index(ClangObject):
 
     def read(self, path):
         """Load a TranslationUnit from the given AST file."""
-        return TranslationUnit.from_ast(path, self)
+        return TranslationUnit.from_ast_file(path, self)
 
     def parse(self, path, args=None, unsaved_files=None, options = 0):
         """Load the translation unit from the given source code file by running
@@ -2656,6 +2785,10 @@ functionList = [
    [Index, c_char_p],
    c_object_p),
 
+  ("clang_CXXMethod_isPureVirtual",
+   [Cursor],
+   bool),
+
   ("clang_CXXMethod_isStatic",
    [Cursor],
    bool),
@@ -3048,6 +3181,11 @@ functionList = [
    _CXString,
    _CXString.from_result),
 
+  ("clang_getTypeSpelling",
+   [Type],
+   _CXString,
+   _CXString.from_result),
+
   ("clang_hashCursor",
    [Cursor],
    c_uint),
@@ -3152,9 +3290,24 @@ functionList = [
    [Cursor],
    bool),
 
+  ("clang_Cursor_getBriefCommentText",
+   [Cursor],
+   _CXString,
+   _CXString.from_result),
+
+  ("clang_Cursor_getRawCommentText",
+   [Cursor],
+   _CXString,
+   _CXString.from_result),
+
   ("clang_Type_getAlignOf",
    [Type],
    c_longlong),
+
+  ("clang_Type_getClassType",
+   [Type],
+   Type,
+   Type.from_result),
 
   ("clang_Type_getOffsetOf",
    [Type, c_char_p],
@@ -3162,7 +3315,11 @@ functionList = [
 
   ("clang_Type_getSizeOf",
    [Type],
-   c_ulonglong),
+   c_longlong),
+
+  ("clang_Type_getCXXRefQualifier",
+   [Type],
+   c_uint),
 ]
 
 class LibclangError(Exception):


### PR DESCRIPTION
Commit 774a936 is a fix for issue #43. I am not sure why this change was made (the commit message is not helpful in that regard).

The other changes bring cindex.py up-to-date with the current clang master version. I have tested this on my own code (https://github.com/rhdunn/cainteoir-engine). Specifically:

Commit 0c1cf77 creates a cldoc/clang/cindex-updates.patch containing the cldoc changes to cindex.py, and a README.md documenting where the source of cindex.py originates. This commit does not change cindex.py.

Commit 9728c1d removes the cldoc changes that remove functions from the functionList. This is needed as some cindex APIs are dependent on those methods.

Commit ecd3dde includes changes that support TypeKind 114 to 117, but before the introduction of cindex.AccessSpecifier. This removes a hunk in the patch.

Commit d534720 only includes the cindex.AccessSpecifier change from clang, and makes cldoc use it instead of cindex.CXXAccessSpecifier.

Finally, commit 009c326 updates cindex.py to the latest version from clang.
