### PR TITLE
Allow operator/ and operator/= documentation to be merged.

### DIFF
--- a/cldoc/documentmerger.py
+++ b/cldoc/documentmerger.py
@@ -108,7 +108,10 @@ class DocumentMerger:
             key = 'doc'
 
             if len(parts) > 1:
-                key = parts[1]
+                if parts[0].endswith('operator'): # for operator/ and operator/=.
+                    qid = self._normalized_qid(category)
+                else:
+                    key = parts[1]
 
             if not self.qid_to_node[qid]:
                 self.add_categories([qid])


### PR DESCRIPTION
This is a fix for documenting `operator/` and `operator/=` in markdown. For example:

```
struct vector {
    const vector &operator/=(int scalar);
};

vector operator/(const vector &v, int scalar);
```

The XML/tree construction is working for this case. However, given the markdown:

```
#<cldoc:vector::operator/=>

Description.

#<cldoc:operator/>

Description.
```

The program fails with e.g. `Unknown type '=' for id 'operator'`. This patch prevents that issue.
