### PR TITLE
pip-install with Python 3 fails because of pyparsing version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ html/styles/cldoc.css
 html/javascript/cldoc.js
 MANIFEST
 node_modules
+cldoc.egg-info

--- a/cldoc/clang/cindex.py
+++ b/cldoc/clang/cindex.py
@@ -529,7 +529,7 @@ class CursorKind(object):
         if value >= len(CursorKind._kinds):
             CursorKind._kinds += [None] * (value - len(CursorKind._kinds) + 1)
         if CursorKind._kinds[value] is not None:
-            raise ValueError,'CursorKind already loaded'
+            raise ValueError('CursorKind already loaded')
         self.value = value
         CursorKind._kinds[value] = self
         CursorKind._name_map = None
@@ -550,7 +550,7 @@ class CursorKind(object):
     @staticmethod
     def from_id(id):
         if id >= len(CursorKind._kinds) or CursorKind._kinds[id] is None:
-            raise ValueError,'Unknown cursor kind %d' % id
+            raise ValueError('Unknown cursor kind %d' % id)
         return CursorKind._kinds[id]
 
     @staticmethod
@@ -1490,7 +1490,7 @@ class TypeKind(object):
         if value >= len(TypeKind._kinds):
             TypeKind._kinds += [None] * (value - len(TypeKind._kinds) + 1)
         if TypeKind._kinds[value] is not None:
-            raise ValueError,'TypeKind already loaded'
+            raise ValueError('TypeKind already loaded')
         self.value = value
         TypeKind._kinds[value] = self
         TypeKind._name_map = None
@@ -1516,7 +1516,7 @@ class TypeKind(object):
     @staticmethod
     def from_id(id):
         if id >= len(TypeKind._kinds) or TypeKind._kinds[id] is None:
-            raise ValueError,'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind %d' % id)
         return TypeKind._kinds[id]
 
     def __repr__(self):
@@ -1583,7 +1583,7 @@ class RefQualifierKind(object):
             num_kinds = value - len(RefQualifierKind._kinds) + 1
             RefQualifierKind._kinds += [None] * num_kinds
         if RefQualifierKind._kinds[value] is not None:
-            raise ValueError, 'RefQualifierKind already loaded'
+            raise ValueError('RefQualifierKind already loaded')
         self.value = value
         RefQualifierKind._kinds[value] = self
         RefQualifierKind._name_map = None
@@ -1605,7 +1605,7 @@ class RefQualifierKind(object):
     def from_id(id):
         if (id >= len(RefQualifierKind._kinds) or
                 RefQualifierKind._kinds[id] is None):
-            raise ValueError, 'Unknown type kind %d' % id
+            raise ValueError('Unknown type kind %d' % id)
         return RefQualifierKind._kinds[id]
 
     def __repr__(self):
@@ -2425,9 +2425,9 @@ class TranslationUnit(ClangObject):
                     # FIXME: It would be great to support an efficient version
                     # of this, one day.
                     value = value.read()
-                    print value
+                    print(value)
                 if not isinstance(value, str):
-                    raise TypeError,'Unexpected unsaved file contents.'
+                    raise TypeError('Unexpected unsaved file contents.')
                 unsaved_files_array[i].name = name
                 unsaved_files_array[i].contents = value
                 unsaved_files_array[i].length = len(value)
@@ -2489,9 +2489,9 @@ class TranslationUnit(ClangObject):
                     # FIXME: It would be great to support an efficient version
                     # of this, one day.
                     value = value.read()
-                    print value
+                    print(value)
                 if not isinstance(value, str):
-                    raise TypeError,'Unexpected unsaved file contents.'
+                    raise TypeError('Unexpected unsaved file contents.')
                 unsaved_files_array[i].name = name
                 unsaved_files_array[i].contents = value
                 unsaved_files_array[i].length = len(value)

--- a/cldoc/inspecttree.py
+++ b/cldoc/inspecttree.py
@@ -23,7 +23,7 @@ def inspect_print_row(a, b, link=None):
     if link:
         b = "<a href='#" + escape(link) + "'>" + b + "</a>"
 
-    print "<tr><td>%s</td><td>%s</td></tr>" % (escape(str(a)), b)
+    print("<tr><td>%s</td><td>%s</td></tr>" % (escape(str(a)), b))
 
 def inspect_print_subtype(name, tp, subtype, indent=1):
     if not subtype or tp == subtype or subtype.kind == cindex.TypeKind.INVALID:
@@ -58,7 +58,7 @@ def inspect_cursor(tree, cursor, indent):
     if not str(cursor.location.file) in tree.files:
         return
 
-    print "<table id='" + escape(cursor.get_usr()) + "' class='cursor' style='margin-left: " + str(indent * 20) + "px;'>"
+    print("<table id='" + escape(cursor.get_usr()) + "' class='cursor' style='margin-left: " + str(indent * 20) + "px;'>")
 
     inspect_print_row('kind', cursor.kind)
     inspect_print_row('  → .is_declaration', cursor.kind.is_declaration())
@@ -93,7 +93,7 @@ def inspect_cursor(tree, cursor, indent):
         for t in cursor.type.argument_types():
             inspect_print_subtype('argument', None, t)
 
-    print "</table>"
+    print("</table>")
 
 def inspect_cursors(tree, cursors, indent=0):
     for cursor in cursors:
@@ -105,22 +105,22 @@ def inspect_cursors(tree, cursors, indent=0):
 def inspect_tokens(tree, filename, tu):
     it = tu.get_tokens(extent=tu.get_extent(filename, (0, os.stat(filename).st_size)))
 
-    print "<table class='tokens'>"
+    print("<table class='tokens'>")
 
     for token in it:
-        print "<tr>"
-        print "<td>%s</td>" % (token.kind,)
-        print "<td>" + token.spelling + "</td>"
-        print "<td>%s</td>" % (token.cursor.kind,)
-        print "<td>%d:%d</td>" % (token.extent.start.line, token.extent.start.column,)
-        print "</tr>"
+        print("<tr>")
+        print("<td>%s</td>" % (token.kind,))
+        print("<td>" + token.spelling + "</td>")
+        print("<td>%s</td>" % (token.cursor.kind,))
+        print("<td>%d:%d</td>" % (token.extent.start.line, token.extent.start.column,))
+        print("</tr>")
 
-    print "</table>"
+    print("</table>")
 
 def inspect(tree):
     index = cindex.Index.create()
 
-    print """<html>
+    print("""<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <style type='text/css'>
@@ -146,7 +146,7 @@ vertical-align: top;
 }
 </style>
 </head>
-<body>"""
+<body>""")
 
     for f in tree.files:
         tu = index.parse(f, tree.flags)
@@ -155,15 +155,15 @@ vertical-align: top;
             sys.stderr.write("Could not parse file %s...\n" % (f,))
             sys.exit(1)
 
-        print "<div class='file'><div class='filename'>" + f + "</div>"
+        print("<div class='file'><div class='filename'>" + f + "</div>")
 
         inspect_tokens(tree, f, tu)
 
         # Recursively inspect cursors
         inspect_cursors(tree, tu.cursor.get_children())
 
-        print "</div>"
+        print("</div>")
 
-    print "</body>\n</html>"
+    print("</body>\n</html>")
 
 # vi:ts=4:et

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,6 @@ setup(name='cldoc',
       },
       package_data={'cldoc': datafiles},
       cmdclass=cmdclass,
-      install_requires=['pyparsing ==1.5.7'])
+      install_requires=['pyparsing>=1.5.7'])
 
 # vi:ts=4:et


### PR DESCRIPTION
Trying to `pip install cldoc` fails like [this](https://gist.github.com/cdeil/6fdbab3447dfc924d7a3#file-gistfile1-txt-L6)

The issue is that in `setup.py` you explicity put `install_requires=['pyparsing ==1.5.7'])` (see [here](https://github.com/jessevdk/cldoc/blob/master/setup.py#L148)

I already have  `pyparsing 2.0.3` on my system ... any reason you can't use that one and e.g. instead require `'pyparsing>=1.5.7'`?

``` bash
$ python -c 'import pyparsing; print(pyparsing.__version__)'
2.0.3
```
