### PR TITLE
compatible with python-2.6

### DIFF
--- a/cldoc/generators/xml.py
+++ b/cldoc/generators/xml.py
@@ -33,8 +33,12 @@ class Xml(Generator):
         except OSError:
             pass
 
-        ElementTree.register_namespace('gobject', 'http://jessevdk.github.com/cldoc/gobject/1.0')
-        ElementTree.register_namespace('cldoc', 'http://jessevdk.github.com/cldoc/1.0')
+        if ElementTree.VERSION[0:3] == '1.2':
+            ElementTree._namespace_map['http://jessevdk.github.com/cldoc/gobject/1.0'] = 'gobject'
+            ElementTree._namespace_map['http://jessevdk.github.com/cldoc/1.0'] = 'cldoc'
+        else:
+            ElementTree.register_namespace('gobject', 'http://jessevdk.github.com/cldoc/gobject/1.0')
+            ElementTree.register_namespace('cldoc', 'http://jessevdk.github.com/cldoc/1.0')
 
         self.index = ElementTree.Element('index')
         self.written = {}
@@ -110,7 +114,10 @@ class Xml(Generator):
         self.indent(tree.getroot())
 
         f = fs.fs.open(os.path.join(self.outdir, fname), 'w')
-        tree.write(f, encoding='utf-8', xml_declaration=True)
+        if ElementTree.VERSION[0:3] == '1.2':
+            tree.write(f, encoding='UTF-8')
+        else:
+            tree.write(f, encoding='UTF-8', xml_declaration=True)
         f.write('\n')
 
         f.close()

--- a/tests/output/abstract-A.xml
+++ b/tests/output/abstract-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" interface="true" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <method abstract="yes" id="A::f" name="f" virtual="yes">
     <brief>A function of A.</brief>

--- a/tests/output/abstract-index.xml
+++ b/tests/output/abstract-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/output/base-A.xml
+++ b/tests/output/base-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <doc>
 The class A.

--- a/tests/output/base-Base.xml
+++ b/tests/output/base-Base.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="Base" interface="true" name="Base" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <subclass access="public" name="A" ref="A#A" />
   <method abstract="yes" id="Base::b" name="b" virtual="yes">

--- a/tests/output/base-index.xml
+++ b/tests/output/base-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
   <class name="Base" ref="Base#Base" />

--- a/tests/output/class-A.xml
+++ b/tests/output/class-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <doc>
 The class A.

--- a/tests/output/class-index.xml
+++ b/tests/output/class-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/output/constructor-A.xml
+++ b/tests/output/constructor-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <constructor id="A::A" name="A">
     <brief>Constructor.</brief>

--- a/tests/output/constructor-index.xml
+++ b/tests/output/constructor-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/output/cstruct-A.xml
+++ b/tests/output/cstruct-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <struct id="A" name="A" typedef="yes" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <field id="A::I" name="I">
     <type builtin="yes" name="int" />

--- a/tests/output/cstruct-index.xml
+++ b/tests/output/cstruct-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <struct name="A" ref="A#A" />
 </index>

--- a/tests/output/destructor-A.xml
+++ b/tests/output/destructor-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <destructor id="A::~A" name="~A">
     <brief>Destructor.</brief>

--- a/tests/output/destructor-index.xml
+++ b/tests/output/destructor-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/output/enum-index.xml
+++ b/tests/output/enum-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <enum anonymous="yes" id="A" name="A">
     <brief> The enum A.</brief>

--- a/tests/output/interface-A.xml
+++ b/tests/output/interface-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" interface="true" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <doc>
 The class A.

--- a/tests/output/interface-Impl.xml
+++ b/tests/output/interface-Impl.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="Impl" name="Impl" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <doc>
 The Impl class.

--- a/tests/output/interface-index.xml
+++ b/tests/output/interface-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
   <class name="Impl" ref="Impl#Impl" />

--- a/tests/output/method-A.xml
+++ b/tests/output/method-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <method id="A::f" name="f">
     <brief>A function of A.</brief>

--- a/tests/output/method-index.xml
+++ b/tests/output/method-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/output/namespace-A.xml
+++ b/tests/output/namespace-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <namespace id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <brief> The namespace A.</brief>
   <doc>Longer description of namespace A.

--- a/tests/output/namespace-A::B.xml
+++ b/tests/output/namespace-A::B.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A::B" name="B" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <brief>Class B.</brief>
   <doc>Class B in namespace A.

--- a/tests/output/namespace-index.xml
+++ b/tests/output/namespace-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <namespace name="A" ref="A#A">
     <brief> The namespace A.</brief>

--- a/tests/output/operator-N.xml
+++ b/tests/output/operator-N.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <namespace id="N" name="N" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <struct name="A" ref="N::A#N::A" />
 </namespace>

--- a/tests/output/operator-N::A.xml
+++ b/tests/output/operator-N::A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <struct id="N::A" interface="true" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <method abstract="yes" id="N::A::operator&lt;" name="operator&lt;">
     <return>

--- a/tests/output/operator-index.xml
+++ b/tests/output/operator-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <namespace name="N" ref="N#N">
     <struct name="A" ref="N::A#N::A" />

--- a/tests/output/struct-A.xml
+++ b/tests/output/struct-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <struct id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <brief> The struct A.</brief>
   <doc>A longer description of A.

--- a/tests/output/struct-index.xml
+++ b/tests/output/struct-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <struct name="A" ref="A#A">
     <brief> The struct A.</brief>

--- a/tests/output/template-A.xml
+++ b/tests/output/template-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <classtemplate id="A" interface="true" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <brief> The class A.</brief>
   <doc>A longer description of A.

--- a/tests/output/template-index.xml
+++ b/tests/output/template-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <classtemplate name="A" ref="A#A">
     <brief> The class A.</brief>

--- a/tests/output/utf8-A.xml
+++ b/tests/output/utf8-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <brief>Copyright ©</brief>
 </class>

--- a/tests/output/utf8-index.xml
+++ b/tests/output/utf8-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A">
     <brief>Copyright ©</brief>

--- a/tests/output/virtual-A.xml
+++ b/tests/output/virtual-A.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <class id="A" name="A" xmlns="http://jessevdk.github.com/cldoc/1.0">
   <method id="A::f" name="f" virtual="yes">
     <brief>A function of A.</brief>

--- a/tests/output/virtual-index.xml
+++ b/tests/output/virtual-index.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <index xmlns="http://jessevdk.github.com/cldoc/1.0">
   <class name="A" ref="A#A" />
 </index>

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -5,7 +5,7 @@ import sys, os
 lcldoc = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, lcldoc)
 
-import unittest
+import unittest2
 from cldoc import cmdgenerate
 
 from cldoc import fs
@@ -15,7 +15,7 @@ from xml import etree
 
 fs.fs = fs.Virtual
 
-class Regression(unittest.TestCase):
+class Regression(unittest2.TestCase):
     def setUp(self):
         pass
 
@@ -70,6 +70,6 @@ def generate_tests():
 generate_tests()
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()
 
 # vi:ts=4:et


### PR DESCRIPTION
Fixes two issues in generators/xml.py when using python-2.6.

The main problem is caused by incompatible between xml.etree.ElementTree-1.2
(used by pyhton-2.6) and xml.etree.ElementTree-1.3 (used by python-2.7).
- ElementTree.register_namespace(prefix, uri)
  Workaround by:
  ElementTree._namespace_map[uri] = prefix
  
  This solution is based on http://goo.gl/Z4Sjtq
- ElementTree.write(file, encoding='utf-8', xml_declaration=True)
  Workaround by:
  ElementTree.write(file, encoding='UTF-8')
  
  This solution is based on http://goo.gl/8K88ow (pls check Olli's answer)

Also replaces unittest by unittest2 which is compitable with python-2.6 and
fixes the tests.
Signed-off-by: Kai Zhang zhangk1985@gmail.com
