### PR TITLE
Fix broken links in static site.

### DIFF
--- a/cldoc/data/staticsite/staticsite.js
+++ b/cldoc/data/staticsite/staticsite.js
@@ -81,7 +81,7 @@ for (var i = 0; i < files.length; i++)
 	$('a').each(function (i, a) {
 		a = $(a);
 
-		var href = a.attr('href');
+		var href = a.attr('href').replace(/::/g, '.');
 
 		if (href.length == 0 || href[0] != '#')
 		{


### PR DESCRIPTION
Since 3526fe7a99c06a16430b5d039cad44d79dcd4191, generated filenames contain :: instead of . as separators. This commit fixes the links in the static site to point to the correct filenames.

Refs #91.