### PR TITLE
loosen restrictions on merger

### DIFF
--- a/cldoc/documentmerger.py
+++ b/cldoc/documentmerger.py
@@ -41,10 +41,6 @@ class DocumentMerger:
                     continue
 
             if line.startswith(prefix) and line.endswith('>'):
-                if len(doc) > 0 and not category:
-                    sys.stderr.write('Failed to merge file `{0}\': no #<cldoc:id> specified\n'.format(filename))
-                    sys.exit(1)
-
                 if category:
                     if not category in ret:
                         ordered.append(category)


### PR DESCRIPTION
this allows us to do something (slightly gross) in order to hide
"cldoc:index" from appearing at the top of a README.md. in particular,
you can now do
<!--
\#<cldoc:index>
My Project
<!--
-->

in order to get cldoc to take README.md yet without putting weird
garbage characters at the start of a document meant for human beings