### PR TITLE
Fix: Treat partial class template specializations correctly

### DIFF
--- a/cldoc/nodes/cclass.py
+++ b/cldoc/nodes/cclass.py
@@ -17,7 +17,7 @@ from .ctype import Type
 from ..clang import cindex
 
 class Class(Node):
-    kind = cindex.CursorKind.CLASS_DECL
+    kinds = [cindex.CursorKind.CLASS_DECL]
 
     class Base:
         def __init__(self, cursor, access=cindex.AccessSpecifier.PUBLIC):

--- a/cldoc/nodes/classtemplate.py
+++ b/cldoc/nodes/classtemplate.py
@@ -18,19 +18,22 @@ from .templated import Templated
 from ..clang import cindex
 
 class StructTemplate(Struct, Templated):
-    kind = None
+    kinds = []
 
     def __init__(self, cursor, comment):
         super(StructTemplate, self).__init__(cursor, comment)
 
 class ClassTemplate(Class, Templated):
-    kind = None
+    kinds = []
 
     def __init__(self, cursor, comment):
         super(ClassTemplate, self).__init__(cursor, comment)
 
 class ClassTemplatePlexer(Node):
-    kind = cindex.CursorKind.CLASS_TEMPLATE
+    kinds = [
+        cindex.CursorKind.CLASS_TEMPLATE,
+        cindex.CursorKind.CLASS_TEMPLATE_PARTIAL_SPECIALIZATION,
+    ]
 
     def __new__(cls, cursor, comment):
         # Check manually if this is actually a struct, so that we instantiate

--- a/cldoc/nodes/constructor.py
+++ b/cldoc/nodes/constructor.py
@@ -15,7 +15,7 @@ from .method import Method
 from ..clang import cindex
 
 class Constructor(Method):
-    kind = cindex.CursorKind.CONSTRUCTOR
+    kinds = [cindex.CursorKind.CONSTRUCTOR]
 
     def __init__(self, cursor, comment):
         Method.__init__(self, cursor, comment)

--- a/cldoc/nodes/conversionfunction.py
+++ b/cldoc/nodes/conversionfunction.py
@@ -15,7 +15,7 @@ from .method import Method
 from ..clang import cindex
 
 class ConversionFunction(Method):
-    kind = cindex.CursorKind.CONVERSION_FUNCTION
+    kinds = [cindex.CursorKind.CONVERSION_FUNCTION]
 
     def __init__(self, cursor, comment):
         Method.__init__(self, cursor, comment)

--- a/cldoc/nodes/cstruct.py
+++ b/cldoc/nodes/cstruct.py
@@ -15,7 +15,7 @@ from .cclass import Class
 from ..clang import cindex
 
 class Struct(Class):
-    kind = cindex.CursorKind.STRUCT_DECL
+    kinds = [cindex.CursorKind.STRUCT_DECL]
 
     def __init__(self, cursor, comment):
         Class.__init__(self, cursor, comment)

--- a/cldoc/nodes/destructor.py
+++ b/cldoc/nodes/destructor.py
@@ -15,7 +15,7 @@ from .method import Method
 from ..clang import cindex
 
 class Destructor(Method):
-    kind = cindex.CursorKind.DESTRUCTOR
+    kinds = [cindex.CursorKind.DESTRUCTOR]
 
     def __init__(self, cursor, comment):
         Method.__init__(self, cursor, comment)

--- a/cldoc/nodes/enum.py
+++ b/cldoc/nodes/enum.py
@@ -15,7 +15,7 @@ from .node import Node
 from ..clang import cindex
 
 class Enum(Node):
-    kind = cindex.CursorKind.ENUM_DECL
+    kinds = [cindex.CursorKind.ENUM_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/enumvalue.py
+++ b/cldoc/nodes/enumvalue.py
@@ -16,7 +16,7 @@ from ..clang import cindex
 from ..cmp import cmp
 
 class EnumValue(Node):
-    kind = cindex.CursorKind.ENUM_CONSTANT_DECL
+    kinds = [cindex.CursorKind.ENUM_CONSTANT_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/field.py
+++ b/cldoc/nodes/field.py
@@ -16,7 +16,7 @@ from .ctype import Type
 from ..clang import cindex
 
 class Field(Node):
-    kind = cindex.CursorKind.FIELD_DECL
+    kinds = [cindex.CursorKind.FIELD_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/function.py
+++ b/cldoc/nodes/function.py
@@ -83,7 +83,7 @@ class Argument:
         return False
 
 class Function(Node):
-    kind = cindex.CursorKind.FUNCTION_DECL
+    kinds = [cindex.CursorKind.FUNCTION_DECL]
 
     def __init__(self, cursor, comment):
         super(Function, self).__init__(cursor, comment)

--- a/cldoc/nodes/functiontemplate.py
+++ b/cldoc/nodes/functiontemplate.py
@@ -19,19 +19,19 @@ from .templated import Templated
 from ..clang import cindex
 
 class FunctionTemplate(Templated, Function):
-    kind = None
+    kinds = []
 
     def __init__(self, cursor, comment):
         super(FunctionTemplate, self).__init__(cursor, comment)
 
 class MethodTemplate(Templated, Method):
-    kind = None
+    kinds = []
 
     def __init__(self, cursor, comment):
         super(MethodTemplate, self).__init__(cursor, comment)
 
 class FunctionTemplatePlexer(Node):
-    kind = cindex.CursorKind.FUNCTION_TEMPLATE
+    kinds = [cindex.CursorKind.FUNCTION_TEMPLATE]
 
     def __new__(cls, cursor, comment):
         if not cursor is None and (cursor.semantic_parent.kind == cindex.CursorKind.CLASS_DECL or \

--- a/cldoc/nodes/method.py
+++ b/cldoc/nodes/method.py
@@ -17,7 +17,7 @@ from ..clang import cindex
 from ..comment import Comment
 
 class Method(Function):
-    kind = cindex.CursorKind.CXX_METHOD
+    kinds = [cindex.CursorKind.CXX_METHOD]
 
     def __init__(self, cursor, comment):
         super(Method, self).__init__(cursor, comment)

--- a/cldoc/nodes/namespace.py
+++ b/cldoc/nodes/namespace.py
@@ -16,7 +16,7 @@ from .root import Root
 from ..clang import cindex
 
 class Namespace(Node):
-    kind = cindex.CursorKind.NAMESPACE
+    kinds = [cindex.CursorKind.NAMESPACE]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/templatetypeparameter.py
+++ b/cldoc/nodes/templatetypeparameter.py
@@ -17,7 +17,7 @@ from ..clang import cindex
 from ..cmp import cmp
 
 class TemplateTypeParameter(Node):
-    kind = cindex.CursorKind.TEMPLATE_TYPE_PARAMETER
+    kinds = [cindex.CursorKind.TEMPLATE_TYPE_PARAMETER]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)
@@ -49,7 +49,7 @@ class TemplateTypeParameter(Node):
         return cmp(self.sort_index, other.sort_index)
 
 class TemplateNonTypeParameter(Node):
-    kind = cindex.CursorKind.TEMPLATE_NON_TYPE_PARAMETER
+    kinds = [cindex.CursorKind.TEMPLATE_NON_TYPE_PARAMETER]
 
     def __init__(self, cursor, comment):
         super(TemplateNonTypeParameter, self).__init__(cursor, comment)

--- a/cldoc/nodes/typedef.py
+++ b/cldoc/nodes/typedef.py
@@ -16,7 +16,7 @@ from .ctype import Type
 from ..clang import cindex
 
 class Typedef(Node):
-    kind = cindex.CursorKind.TYPEDEF_DECL
+    kinds = [cindex.CursorKind.TYPEDEF_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/union.py
+++ b/cldoc/nodes/union.py
@@ -16,7 +16,7 @@ from ..clang import cindex
 from ..cmp import cmp
 
 class Union(Node):
-    kind = cindex.CursorKind.UNION_DECL
+    kinds = [cindex.CursorKind.UNION_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/nodes/variable.py
+++ b/cldoc/nodes/variable.py
@@ -16,7 +16,7 @@ from .ctype import Type
 from ..clang import cindex
 
 class Variable(Node):
-    kind = cindex.CursorKind.VAR_DECL
+    kinds = [cindex.CursorKind.VAR_DECL]
 
     def __init__(self, cursor, comment):
         Node.__init__(self, cursor, comment)

--- a/cldoc/tree.py
+++ b/cldoc/tree.py
@@ -97,8 +97,9 @@ class Tree(documentmerger.DocumentMerger):
         # Create a map from CursorKind to classes representing those cursor
         # kinds.
         for cls in nodes.Node.subclasses():
-            if hasattr(cls, 'kind'):
-                self.kindmap[cls.kind] = cls
+            if hasattr(cls, 'kinds'):
+                for kind in cls.kinds:
+                    self.kindmap[kind] = cls
 
         self.root = nodes.Root()
 


### PR DESCRIPTION
cldoc currently does not generate nodes for partial template class specializations. It still tries to process its children, which receive the containing namespace as parent (fallback). This causes problems elsewhere, e.g. if the child is a method, it expects its parent to be a class.

This PR models partial template class specializations as class templates, fixing this issue. The change requires Node types to map to multiple kinds.