### PR TITLE
Python3 fixes

### DIFF
--- a/cldoc/nodes/field.py
+++ b/cldoc/nodes/field.py
@@ -23,6 +23,8 @@ class Field(Node):
         self.type = Type(cursor.type, cursor=cursor)
 
     def compare_same(self, other):
+        def cmp(a, b):
+            return (a > b) - (a < b)
         return cmp(self.sort_index, other.sort_index)
 
 # vi:ts=4:et

--- a/cldoc/nodes/function.py
+++ b/cldoc/nodes/function.py
@@ -99,8 +99,6 @@ class Function(Node):
 
     @property
     def semantic_parent(self):
-        from namespace import Namespace
-
         parent = self.parent
 
         while not parent is None and not isinstance(parent, Namespace):


### PR DESCRIPTION
Running cldoc with current Python 3.6.5 required two patches:
- Python3 does not provide `cmp()`, re-defining manually
- Removing an unused, incorrect module import