### PR TITLE
Do not fail on UTF-8 decoding errors

### DIFF
--- a/cldoc/clang/cindex.py
+++ b/cldoc/clang/cindex.py
@@ -98,7 +98,7 @@ if sys.version_info[0] == 3:
         def value(self):
             if super(c_char_p, self).value is None:
                 return None
-            return super(c_char_p, self).value.decode("utf8")
+            return super(c_char_p, self).value.decode("utf8", errors="replace")
 
         @classmethod
         def from_param(cls, param):


### PR DESCRIPTION
The standard does not require C/C++ files to be valid UTF-8. Replace invalid characters when decoding identifiers.